### PR TITLE
Adds Code of Conduct directly into repo

### DIFF
--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of  
+fostering an open and welcoming community, we pledge to respect all people who  
+contribute through reporting issues, posting feature requests, updating  
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free  
+experience for everyone, regardless of level of experience, gender, gender  
+identity and expression, sexual orientation, disability, personal appearance,  
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or  
+reject comments, commits, code, wiki edits, issues, and other contributions  
+that are not aligned to this Code of Conduct, or to ban temporarily or  
+permanently any contributor for other behaviors that they deem inappropriate,  
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to  
+fairly and consistently applying these principles to every aspect of managing  
+this project. Project maintainers who do not follow or enforce the Code of  
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces  
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be  
+reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com) or [orta.therox@gmail.com](mailto:orta.therox@gmail.com). All  
+complaints will be reviewed and investigated and will result in a response that  
+is deemed necessary and appropriate to the circumstances. Maintainers are  
+obligated to maintain confidentiality with regard to the reporter of an  
+incident.  
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Moya Contributors Guidelines v1.0.0
+### Moya Contributors Guidelines v1.1.0
 
 ##### Background
 
@@ -34,7 +34,7 @@ It's normal for a first PR to be a potential fix for a problem, moving on from t
 
 We keep all project discussion inside GitHub issues. If you have questions about how to use the library, or how the project is running GitHub issues are the [goto tool](https://github.com/Moya/Moya/issues/new).
 
-We have our own [Code of Conduct](https://github.com/Moya/code-of-conduct), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/). The CoC is taken seriously by the project owners.
+We have our own [Code of Conduct](Code of Conduct.md), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/). The CoC is taken seriously by the project owners.
 
 #### Our expectations on you as a contributor
 


### PR DESCRIPTION
This also updates our Code of Conduct from 1.2.0 to the most recent 1.3.0.

Subsequently, I've bumped our own semantic version.

Fixes https://github.com/Moya/code-of-conduct/issues/1
