### PR TITLE
[v2] Initial stab a separating into a Community Continuity Guidelines

### DIFF
--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -1,47 +1,48 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of
-fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating
+As contributors and maintainers of this project, and in the interest of  
+fostering an open and welcoming community, we pledge to respect all people who  
+contribute through reporting issues, posting feature requests, updating  
 documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
+We are committed to making participation in this project a harassment-free  
+experience for everyone, regardless of level of experience, gender, gender  
+identity and expression, sexual orientation, disability, personal appearance,  
 body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing other's private information, such as physical or electronic
-  addresses, without explicit permission
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
 * Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+Project maintainers have the right and responsibility to remove, edit, or  
+reject comments, commits, code, wiki edits, issues, and other contributions  
+that are not aligned to this Code of Conduct, or to ban temporarily or  
+permanently any contributor for other behaviors that they deem inappropriate,  
 threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
+By adopting this Code of Conduct, project maintainers commit themselves to  
+fairly and consistently applying these principles to every aspect of managing  
+this project. Project maintainers who do not follow or enforce the Code of  
 Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces
+This code of conduct applies both within project spaces and in public spaces  
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com) or [orta.therox@gmail.com](mailto:orta.therox@gmail.com). All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be  
+reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com) or [orta.therox@gmail.com](mailto:orta.therox@gmail.com). All  
+complaints will be reviewed and investigated and will result in a response that  
+is deemed necessary and appropriate to the circumstances. Maintainers are  
+obligated to maintain confidentiality with regard to the reporter of an  
+incident.  
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
 version 1.3.0, available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 

--- a/Code of Conduct.md
+++ b/Code of Conduct.md
@@ -1,48 +1,47 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of  
-fostering an open and welcoming community, we pledge to respect all people who  
-contribute through reporting issues, posting feature requests, updating  
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
 documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free  
-experience for everyone, regardless of level of experience, gender, gender  
-identity and expression, sexual orientation, disability, personal appearance,  
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
 body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery  
-* Personal attacks  
-* Trolling or insulting/derogatory comments  
-* Public or private harassment  
-* Publishing other's private information, such as physical or electronic  
-  addresses, without explicit permission  
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
 * Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or  
-reject comments, commits, code, wiki edits, issues, and other contributions  
-that are not aligned to this Code of Conduct, or to ban temporarily or  
-permanently any contributor for other behaviors that they deem inappropriate,  
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to  
-fairly and consistently applying these principles to every aspect of managing  
-this project. Project maintainers who do not follow or enforce the Code of  
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
 Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces  
+This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be  
-reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com) or [orta.therox@gmail.com](mailto:orta.therox@gmail.com). All  
-complaints will be reviewed and investigated and will result in a response that  
-is deemed necessary and appropriate to the circumstances. Maintainers are  
-obligated to maintain confidentiality with regard to the reporter of an  
-incident.  
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at [ash@ashfurrow.com](mailto:ash@ashfurrow.com) or [orta.therox@gmail.com](mailto:orta.therox@gmail.com). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
 
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 

--- a/Community.md
+++ b/Community.md
@@ -1,36 +1,28 @@
 # Community Continuity Guidelines v2.0.0
 
-As the creators, and maintainers of this project, we want to ensure that the project lives and continues to grow. Not blocked by any singular person's computer time.
-
-One of the simplest ways of doing this is by encouraging a larger set of shallow contributors.
+As the creators, and maintainers of this project, we want to ensure that the project lives and continues to grow. Not blocked by any singular person's computer time. One of the simplest ways of doing this is by encouraging a larger set of shallow contributors. Through this, we hope to mitigate the problems of a project that needs updates but there's no-one who has the power to do so.
 
 #### Ownership
 
-If you get a merged Pull Request, regardless of content (typos, code, doc fixes), then you're eligible for push access to this organization. We check for this on PR merges and extend an invite via GitHub.
+If you get a merged Pull Request, regardless of content (typos, code, doc fixes), then you're eligible for push access to this organization. This is checked for on pull request merges and an invite to the organization is sent via GitHub.
 
-Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project. If you are working with a codebase, then you probably have the skills to improve it and offer valuable feedback.
+Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project. If you are building a project that relies on this codebase, then you probably have the skills to improve it and offer valuable feedback.
 
 Everyone comes in with their own perspective on what a project could/should look like, and encouraging discussion can help expose good ideas sooner.
 
 #### Why do we give out push access?
 
-It can be overwhelming to suddenly be offered the chance to wipe the source code for a project. Don't worry, we don't let you push to master.
+It can be overwhelming to offered the chance to wipe the source code for a project. Don't worry, we don't let you push to master. All code is peer-reviewed, and we have the convention that someone other than the submitter should merge non-trivial pull requests.
 
-All code is peer-reviewed, and we have the convention that someone other than the submitter should merge the pull request.
+As an organization contributor, you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to jump in and take a code review on topics that interest you.
 
-As an organization contributor, you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to just jump in and take a code review on things that interest you.
-
-If it feels right, merge.
-
-This project is not continuously deployed, there is space for debate after review too. Offering the chance to revert, or make an amending pull request.
-
-It's convention to provide a call to action via `/cc @[org]/contributors` to invite discussion.
+This project is not continuously deployed, there is space for debate after review too. Offering everyone the chance to revert, or make an amending pull request. If it feels right, merge.
 
 #### How can we help you get comfortable contributing?
 
-It's normal for a first PR to be a potential fix for a problem, and moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering good first step issues. These issues can be done without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined. They will be purposely avoided by mature contributors to the project.
+It's normal for a first pull request to be a potential fix for a problem, and moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering good first step issues. These issues can be fixed without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined. They will be purposely avoided by mature contributors to the project. To make space for others.
 
-We aim to keep all project discussion inside GitHub issues. This is to make sure it is public. If you have questions about how to use the library, or how the project is running - GitHub issues are the goto tool for this project.
+We aim to keep all project discussion inside GitHub issues. This is to make sure valuable discussion is accessible via search. If you have questions about how to use the library, or how the project is running - GitHub issues are the goto tool for this project.
 
 #### Our expectations on you as a contributor
 
@@ -40,18 +32,21 @@ To quote [@alloy](https://github.com/alloy) from [this issue](https://github.com
 
 We want contributors to provide ideas, keep the ship shipping and to take some of the load from others. It is non-obligatory; we’re here to get things done in an enjoyable way. :trophy:
 
-The fact that you'll have push access would allow you to:
+The fact that you'll have push access will allow you to:
 
-- Avoid having to fork the project if you want to submit other PRs as you'll be able to create branches directly on the project.
-- Help triage issues, merge PRs if you choose.
-- The option to pick up the project if other maintainers move their focus elsewhere.
+- Avoid having to fork the project if you want to submit other pull requests as you'll be able to create branches directly on the project.
+- Help triage issues, merge pull requests.
+- Pick up the project if other maintainers move their focus elsewhere.
 
-However it's up to you to use those superpowers or not 😉
-
+It's up to you to use those superpowers or not though 😉
 
 If someone submits a pull request that's not perfect, and you are reviewing, it's better to think about the PR's motivation rather than the specific implementation. Having braces on the wrong line should not be a blocker. Though we do want to keep test coverage high, we will work with you to figure that out together.
 
-#### What about if you have problems that cannot be put into a public issue?
+#### What about if you have problems that cannot be discussed in a public issue?
 
 [ This is an example version, please delete this and replace with your own version ]
 Both [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta) have contactable emails on their GitHub profiles, and are happy to talk about any problems.
+
+#### Where can I get more info about this document?
+
+The original source of this document can is at https://github.com/moya/contributors

--- a/Community.md
+++ b/Community.md
@@ -45,8 +45,8 @@ If someone submits a pull request that's not perfect, and you are reviewing, it'
 #### What about if you have problems that cannot be discussed in a public issue?
 
 [ This is an example version, please delete this and replace with your own version ]
-Both [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta) have contactable emails on their GitHub profiles, and are happy to talk about any problems.
+Both [Jane Bloggs](https://github.com/jane_b) and [Taylor Webb](https://github.com/twebb) have contactable emails on their GitHub profiles, and are happy to talk about any problems.
 
 #### Where can I get more info about this document?
 
-The original source of this document can is at https://github.com/moya/contributors
+The original source of this document can be found at https://github.com/moya/contributors.

--- a/Community.md
+++ b/Community.md
@@ -1,0 +1,47 @@
+# Community Continuity Guidelines v2.0.0
+
+As the creators, and maintainers of this project. We want to ensure that the project lives and continues to grow. Not blocked by any singular person's computer time.
+
+One of the simplest ways of doing this, is by encouraging a larger set of shallow contributors.
+
+#### Ownership
+
+If you get a merged PR, regardless of content (typos, code, doc fixes) then you're eligible for push access to this organization. We check for this on PR merges and extend an invite via GitHub.
+
+Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project. If you are working with a codebase, then you probably have the skills to improve it, and offer valuable feedback.
+
+Everyone comes in with their own perspective on what a project could/should look like, and encouraging discussion can help expose good ideas sooner.
+
+#### Why do we give out push access?
+
+It can be overwhelming to suddenly be offered the chance to wipe the source code for a project. Don't worry, we don't let you push to master.
+
+All code is peer-reviewed, and we have the convention that someone other than the submitter should merge the pull request.
+
+As an organization contributor you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to just jump in and take a code review on things that interest you.
+
+If it feels right, merge.
+
+This project is not continuously deployed, there is space for debate after review too. Offering the chance to revert, or make an amending pull request.
+
+It's convention to provide a call to action via `/cc @[org]/contributors` to invite discussion.
+
+#### How can we help you get comfortable contributing?
+
+It's normal for a first PR to be a potential fix for a problem, moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering good first step issues. These issues can be done without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined. They will be purposely avoided by mature contributors to the project.
+
+We aim keep all project discussion inside GitHub issues. This is to make sure it is public. If you have questions about how to use the library, or how the project is running GitHub issues are the goto tool.
+
+#### Our expectations on you as a contributor
+
+To quote [@alloy](https://github.com/alloy) from [this issue](https://github.com/Moya/Moya/issues/135):
+
+> Don't ever feel bad for not contributing to open source.
+
+We want contributors to both provide ideas, keep the ship shipping and to take some of the load from others. It is non-obligatory; we're here to have fun. :trophy:
+
+If someone submits a pull request that's not perfect, and you are reviewing, it's better to think about the PR's motivation rather than the specific implementation. Having braces on the wrong line should not be a blocker. Though we do want to keep test coverage high, we will work with you to figure that out together.
+
+#### What about if you have problems that cannot be put into a public issue?
+
+Both [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta) have contactable emails on their GitHub profiles, and are happy to talk about any problems.

--- a/Community.md
+++ b/Community.md
@@ -1,14 +1,14 @@
 # Community Continuity Guidelines v2.0.0
 
-As the creators, and maintainers of this project. We want to ensure that the project lives and continues to grow. Not blocked by any singular person's computer time.
+As the creators, and maintainers of this project, we want to ensure that the project lives and continues to grow. Not blocked by any singular person's computer time.
 
-One of the simplest ways of doing this, is by encouraging a larger set of shallow contributors.
+One of the simplest ways of doing this is by encouraging a larger set of shallow contributors.
 
 #### Ownership
 
-If you get a merged PR, regardless of content (typos, code, doc fixes) then you're eligible for push access to this organization. We check for this on PR merges and extend an invite via GitHub.
+If you get a merged Pull Request, regardless of content (typos, code, doc fixes), then you're eligible for push access to this organization. We check for this on PR merges and extend an invite via GitHub.
 
-Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project. If you are working with a codebase, then you probably have the skills to improve it, and offer valuable feedback.
+Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project. If you are working with a codebase, then you probably have the skills to improve it and offer valuable feedback.
 
 Everyone comes in with their own perspective on what a project could/should look like, and encouraging discussion can help expose good ideas sooner.
 
@@ -18,7 +18,7 @@ It can be overwhelming to suddenly be offered the chance to wipe the source code
 
 All code is peer-reviewed, and we have the convention that someone other than the submitter should merge the pull request.
 
-As an organization contributor you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to just jump in and take a code review on things that interest you.
+As an organization contributor, you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to just jump in and take a code review on things that interest you.
 
 If it feels right, merge.
 
@@ -28,9 +28,9 @@ It's convention to provide a call to action via `/cc @[org]/contributors` to inv
 
 #### How can we help you get comfortable contributing?
 
-It's normal for a first PR to be a potential fix for a problem, moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering good first step issues. These issues can be done without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined. They will be purposely avoided by mature contributors to the project.
+It's normal for a first PR to be a potential fix for a problem, and moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering good first step issues. These issues can be done without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined. They will be purposely avoided by mature contributors to the project.
 
-We aim keep all project discussion inside GitHub issues. This is to make sure it is public. If you have questions about how to use the library, or how the project is running GitHub issues are the goto tool.
+We aim to keep all project discussion inside GitHub issues. This is to make sure it is public. If you have questions about how to use the library, or how the project is running - GitHub issues are the goto tool for this project.
 
 #### Our expectations on you as a contributor
 
@@ -38,10 +38,20 @@ To quote [@alloy](https://github.com/alloy) from [this issue](https://github.com
 
 > Don't ever feel bad for not contributing to open source.
 
-We want contributors to both provide ideas, keep the ship shipping and to take some of the load from others. It is non-obligatory; we're here to have fun. :trophy:
+We want contributors to provide ideas, keep the ship shipping and to take some of the load from others. It is non-obligatory; we’re here to get things done in an enjoyable way. :trophy:
+
+The fact that you'll have push access would allow you to:
+
+- Avoid having to fork the project if you want to submit other PRs as you'll be able to create branches directly on the project.
+- Help triage issues, merge PRs if you choose.
+- The option to pick up the project if other maintainers move their focus elsewhere.
+
+However it's up to you to use those superpowers or not 😉
+
 
 If someone submits a pull request that's not perfect, and you are reviewing, it's better to think about the PR's motivation rather than the specific implementation. Having braces on the wrong line should not be a blocker. Though we do want to keep test coverage high, we will work with you to figure that out together.
 
 #### What about if you have problems that cannot be put into a public issue?
 
+[ This is an example version, please delete this and replace with your own version ]
 Both [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta) have contactable emails on their GitHub profiles, and are happy to talk about any problems.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Moya started out as a project in Artsy under the ownership of [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta). Over time, developers from the community began using Moya and it became a community-driven project.
 
-After watching [The Social Coding Contract](http://blog.testdouble.com/posts/2014-12-02-the-social-coding-contract.html) we opted to find ways to make [the project](https://github.com/Moya/Moya/issues/135) more welcoming to external contributors.
+After watching [The Social Coding Contract](http://blog.testdouble.com/posts/2014-12-02-the-social-coding-contract.html) we looked to find ways to make [the project](https://github.com/Moya/Moya/issues/135) more welcoming to external contributors.
 
-Because of the created the [Moya Community document](https://github.com/Moya/contributors/blob/0d5e80682b2377bdca72585eda9ce83467bee3c4/README.md) - over time this has been adopted in more projects.
+Because of this, we created the [v1 Moya Community document](https://github.com/Moya/contributors/blob/0d5e80682b2377bdca72585eda9ce83467bee3c4/README.md) - over time the ideas have spread to more projects. This eventually lead to the creation of a more easily applicable template.
 
 This repo contains a document [Community.md](Community.md) which is a template for others to help foster their own communities. Think of it as a code of conduct for the continuity of your community.
 
@@ -18,8 +18,7 @@ Great! So, this is not quite another file to copy & paste into your project. It'
 It's not too many steps though, and the majority of them are common sense things you would do anyway.
 
 - [ ] Copy the Changelog.md into your repo
-  - Change [email] to your email
-  - Change [org] to your organization
+  - Change the bottom paragraph to show how people can contact organizers privately 
 
 - [ ] Ensure that it makes sense when the guidelines talk about it not being continuously deployed. If it doesn't make sense, remove it.
   - For example, in a library, you have to deploy to a package manager. This means there is always a chance for cleanup and final reviews before a release.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Great! So, this is not quite another file to copy & paste into your project. It'
 It's not too many steps though, and the majority of them are common sense things you would do anyway.
 
 - [ ] Copy the Changelog.md into your repo
-  - Change the bottom paragraph to show how people can contact organizers privately 
+  - Change the bottom paragraph to show how people can contact organizers privately
 
 - [ ] Ensure that it makes sense when the guidelines talk about it not being continuously deployed. If it doesn't make sense, remove it.
   - For example, in a library, you have to deploy to a package manager. This means there is always a chance for cleanup and final reviews before a release.
@@ -31,6 +31,11 @@ It's not too many steps though, and the majority of them are common sense things
 - [ ] Fill out the "What about if you have problems that cannot be put into a public issue?" section at the end.
 
 And you're good. In our opinion, you're also welcome to add some flourish at the top about why you want to work this way. This is not legal, binding documentation, and doesn't aim to be.
+
+### Useful Bits of information for project owners
+
+- [Danger](https://github.com/danger/danger) is a project that can be used during CI that can check to see if someone is inside an organization, making it possible to ask if they would like to be invited.
+- There has been discussion in the issues here about building a service that could automate this. If it's something you're interested in, you're welcome to take a shot at it.
 
 ### I want to improve the Community Continuity Guidelines
 

--- a/README.md
+++ b/README.md
@@ -17,24 +17,23 @@ Great! So, this is not quite another file to copy & paste into your project. It'
 
 It's not too many steps though, and the majority of them are common sense things you would do anyway.
 
-- [ ] Copy the Changelog.md into your repo
-  - Change the bottom paragraph to show how people can contact organizers privately
+- [ ] Copy the file `Community.md` into your repo.
+- [ ] Change the bottom paragraph to show how people can contact organizers privately
 
-- [ ] Ensure that it makes sense when the guidelines talk about it not being continuously deployed. If it doesn't make sense, remove it.
+- [ ] Ensure that it makes sense when the guidelines talk about the project not being continuously deployed. If it doesn't make sense, remove it.
   - For example, in a library, you have to deploy to a package manager. This means there is always a chance for cleanup and final reviews before a release.
 
-- [ ] Lock the master branch, to ensure code review as the way to get code in. Even for admins. Everyone plays by the rules.
+- [ ] [Lock the master branch](https://help.github.com/articles/configuring-protected-branches/), to ensure code review as the way to get code in. Even for admins. Everyone plays by the rules.
 
-- [ ] Ensure there is a label for people to find easy issues with
-  - We strongly recommend you use a [label name from one of this set](https://github.com/Charlotteis/libraries.io/blob/6afea1a3354aef4672d9b3a9fc4cc308d60020c8/app/models/github_issue.rb#L8-L14) in order to get larger appeal.
+- [ ] Ensure there is a label for people to find easy issues with. We strongly recommend you use a [label name from one of this set](https://github.com/Charlotteis/libraries.io/blob/6afea1a3354aef4672d9b3a9fc4cc308d60020c8/app/models/github_issue.rb#L8-L14) in order to be invovled with the larger ecosystem.
 
-- [ ] Fill out the "What about if you have problems that cannot be put into a public issue?" section at the end.
+And you're good. 
 
-And you're good. In our opinion, you're also welcome to add some flourish at the top about why you want to work this way. This is not legal, binding documentation, and doesn't aim to be.
+In our opinion, you're also welcome to add some flourish at the top about why you want to work this way. This is not a legal document, and doesn't aim to be, offering insight into why you choose to work this way can make the document a nicer read.
 
 ### Useful Bits of information for project owners
 
-- [Danger](https://github.com/danger/danger) is a project that can be used during CI that can check to see if someone is inside an organization, making it possible to ask if they would like to be invited.
+- [Danger](https://github.com/danger/danger) is a project that can be used during CI that can check to see [if someone is inside an organization](https://github.com/danger/danger/blob/93f4f1e92f9748ab04a148b6c60c431a0247efcc/Dangerfile#L7-L15), making it possible to ask if they would like to be invited.
 - There has been discussion in the issues here about building a service that could automate this. If it's something you're interested in, you're welcome to take a shot at it.
 
 ### I want to improve the Community Continuity Guidelines

--- a/README.md
+++ b/README.md
@@ -1,51 +1,48 @@
-### Moya Contributors Guidelines v1.1.0
-
+### Moya Community Continuity Guidelines v2.0.0
 ##### Background
 
-Moya started out as a project in Artsy under the ownership of [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta). Over time, developers from the community began using Moya and it is now a community-driven project.
+Moya started out as a project in Artsy under the ownership of [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta). Over time, developers from the community began using Moya and it became a community-driven project.
 
 After watching [The Social Coding Contract](http://blog.testdouble.com/posts/2014-12-02-the-social-coding-contract.html) we opted to find ways to make [the project](https://github.com/Moya/Moya/issues/135) more welcoming to external contributors.
 
-This document tries to clarify how we can include as many people as possible within the project.
+Because of the created the [Moya Community document](https://github.com/Moya/contributors/blob/0d5e80682b2377bdca72585eda9ce83467bee3c4/README.md) - over time this has been adopted in more projects.
 
-#### How to get push access?
+This repo contains a document [Community.md](Community.md) which is a template for others to help foster their own communities. Think of it as a code of conduct for the continuity of your community.
 
-If you get a merged PR, regardless of content (typos, code, doc fixes) then you're eligible for push access to the Moya organization. We check for this on PR merges and extend an invite via GitHub.
+---------
 
-Offhand, it's easy to imagine that this would make code quality suffer, but in reality it offers fresh perspectives to the codebase and encourages ownership from people who are depending on the project.
+### I want to apply these guidelines
 
-Everyone comes in with their own perspective on what a project could/should look like, and encouraging discussion can help expose good ideas sooner.
+Great! So, this is not quite another file to copy & paste into your project. It's slightly more involved.
 
-#### When should you use push access?
+It's not too many steps though, and the majority of them are common sense things you would do anyway.
 
-It can be overwhelming to suddenly be offered the chance to wipe the source code for a project. Don't worry, we don't let you push to master.
+- [ ] Copy the Changelog.md into your repo
+  - Change [email] to your email
+  - Change [org] to your organization
 
-All code is peer-reviewed, and we have the convention that someone other than the submitter should merge the pull request.
+- [ ] Ensure that it makes sense when the guidelines talk about it not being continuously deployed. If it doesn't make sense, remove it.
+  - For example, in a library, you have to deploy to a package manager. This means there is always a chance for cleanup and final reviews before a release.
 
-As an org contributor you can merge other people's pull requests, or other contributors can merge yours. You won't be assigned a pull request, but you're welcome to just jump in and take a code review on things that interest you.
+- [ ] Lock the master branch, to ensure code review as the way to get code in. Even for admins. Everyone plays by the rules.
 
-If it feels right, merge. Moya is not continuously deployed, there is space for debate after too. Offering the chance to revert, or make an amending pull request.
+- [ ] Ensure there is a label for people to find easy issues with
+  - We strongly recommend you use a [label name from one of this set](https://github.com/Charlotteis/libraries.io/blob/6afea1a3354aef4672d9b3a9fc4cc308d60020c8/app/models/github_issue.rb#L8-L14) in order to get larger appeal.
 
-It's convention to provide a call to action [via](https://github.com/Moya/Moya/pull/273) `/cc @Moya/contributors` to invite discussion.
+- [ ] Fill out the "What about if you have problems that cannot be put into a public issue?" section at the end.
 
-#### How can we help you get comfortable contributing?
+And you're good. In our opinion, you're also welcome to add some flourish at the top about why you want to work this way. This is not legal, binding documentation, and doesn't aim to be.
 
-It's normal for a first PR to be a potential fix for a problem, moving on from there to helping the project's direction can be difficult. We try to help contributors cross that barrier by offering [good first step](https://github.com/Moya/Moya/labels/good%20first%20step) issues. These issues can be done without feeling like you're stepping on toes. Ideally, these are non-critical issues that are well defined.
+### I want to improve the Community Continuity Guidelines
 
-We keep all project discussion inside GitHub issues. If you have questions about how to use the library, or how the project is running GitHub issues are the [goto tool](https://github.com/Moya/Moya/issues/new).
+Great, so do we. Feedback in issues is a great way to work, as is pull requests  improving our wording. This is an evolving document, so we'll be trying to apply [Semantic Versioning](http://semver.org) to it.
 
-We have our own [Code of Conduct](Code of Conduct.md), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/). The CoC is taken seriously by the project owners.
+We consider extra guidelines as being major releases, tweaks to existing rules as minors, and depending on other wording changes - patches. We'll be using our best judgement as we can.
 
-#### Our expectations on you as a contributor
+### This Repo
 
-To quote [@alloy](https://github.com/alloy) from [this issue](https://github.com/Moya/Moya/issues/135):
+We use a [Code of Conduct](Code of Conduct.md), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/). The CoC is taken seriously by the project owners.
 
-> Don't ever feel bad for not contributing to open source.
-
-We want contributors to both provide ideas, keep the ship shipping and to take some of the load from others. It is non-obligatory; we're here to have fun. :trophy:
-
-If someone submits a pull request that's not perfect, it's better to think about the PR's motivation rather than the specific implementation. Having braces on the wrong line should not be a blocker for example. Though we do want to keep test coverage high, we will work with you to [figure that out together](https://github.com/ashfurrow/Nimble-Snapshots/pull/37).
-
-#### What about if you have problems that cannot be put into a public issue?
+#### What about if you have questions that cannot be put into a public issue?
 
 Both [Ash Furrow](https://github.com/ashfurrow) and [Orta Therox](https://github.com/orta) have contactable emails on their GitHub profiles, and are happy to talk about any problems.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ This repo contains a document [Community.md](Community.md) which is a template f
 
 ### I want to apply these guidelines
 
-Great! So, this is not quite another file to copy & paste into your project. It's slightly more involved.
+Great! So, this is not quite another file to copy & paste into your project. It's slightly more involved. 
 
 It's not too many steps though, and the majority of them are common sense things you would do anyway.
 
 - [ ] Copy the file `Community.md` into your repo.
 - [ ] Change the bottom paragraph to show how people can contact organizers privately
-
 - [ ] Ensure that it makes sense when the guidelines talk about the project not being continuously deployed. If it doesn't make sense, remove it.
   - For example, in a library, you have to deploy to a package manager. This means there is always a chance for cleanup and final reviews before a release.
 
@@ -35,6 +34,12 @@ In our opinion, you're also welcome to add some flourish at the top about why yo
 
 - [Danger](https://github.com/danger/danger) is a project that can be used during CI that can check to see [if someone is inside an organization](https://github.com/danger/danger/blob/93f4f1e92f9748ab04a148b6c60c431a0247efcc/Dangerfile#L7-L15), making it possible to ask if they would like to be invited.
 - There has been discussion in the issues here about building a service that could automate this. If it's something you're interested in, you're welcome to take a shot at it.
+
+##### Other references
+
+* The [Jekyll Project](https://github.com/jekyll/jekyll) has some great documentation around [being a maintainer, and avoiding burnout](https://github.com/jekyll/jekyll/pull/5011/files).
+* The Jekyll's maintainer documentation is based on [Homebrew's](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Maintainers-Avoiding-Burnout.md).
+* CocoaPods has a [Communication & Design Rules](https://github.com/CocoaPods/CocoaPods/wiki/Communication-&-Design-Rules) which provides advice for project maintainers.
 
 ### I want to improve the Community Continuity Guidelines
 


### PR DESCRIPTION
Fixes #6 

---

OK, so, long time coming - thanks @paulofaria for our conversations recently. 

This splits out the README into the "moya/contributors README" and the `Community.md` file. The idea being that the README shows you how to get up and running, the `Community.md` is what you take into your own project and modify to your specifics. 

I'll be running through this for Danger, and the CocoaPods app ( both of which have different approaches to how this can be tackled ) before I can start to expand it further

@ashfurrow I want you to run through this for Moya/Moya - it's an oddity, but I think it makes sense. Plus having someone else run through the process will be helpful.

I think I'd advocate for renaming this repo to `community-continuity` too once this is merged and we've settled on what v2 is.

---

/cc @dbgrandi @ashfurrow @paulofaria @krausefx @segiddins @AliSoftware - would love feedback

What I'd like is focus on the new [Community.md](https://github.com/Moya/contributors/blob/v2/Community.md) which should feel reasonable in any project's repo.
