### PR TITLE
Add a first draft of Changelog Guidelines.

### DIFF
--- a/Changelog Guidelines.md
+++ b/Changelog Guidelines.md
@@ -1,0 +1,17 @@
+# Changelog Guidelines
+
+We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) with additions: 
+
+- PR number at the end of the entry
+- **Breaking change** label in breaking change entries. Additionally these entries should be at the top of the list of changes.
+
+Example:
+
+## [9.0.0] - 2017-09-04
+### Added
+- Tests for `Single<Response>` operators from @freak4pc (#1229).
+
+### Removed
+- **Breaking Change** Parameters & parameterEncoding in `TargetType` from @Dschee (#1147).
+- Default value for `task` parameter in `Endpoint` initializer.
+

--- a/Changelog Guidelines.md
+++ b/Changelog Guidelines.md
@@ -5,7 +5,7 @@ We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.
 - PR number at the end of the entry
 - **Breaking change** label in breaking change entries. Additionally these entries should be at the top of the list of changes.
 
-Example:
+## Example:
 
 ## [9.0.0] - 2017-09-04
 ### Added
@@ -13,5 +13,5 @@ Example:
 
 ### Removed
 - **Breaking Change** Parameters & parameterEncoding in `TargetType` from @Dschee (#1147).
-- Default value for `task` parameter in `Endpoint` initializer.
+- Default value for `task` parameter in `Endpoint` initializer from @SD10 (#1252).
 

--- a/Changelog Guidelines.md
+++ b/Changelog Guidelines.md
@@ -9,9 +9,9 @@ We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.
 
 ## [9.0.0] - 2017-09-04
 ### Added
-- Tests for `Single<Response>` operators from [@freak4pc](http://github.com/freak4pc) (#1229).
+- Tests for `Single<Response>` operators from [@freak4pc](http://github.com/freak4pc) ([#1229](https://github.com/Moya/Moya/pull/1229)).
 
 ### Removed
-- **Breaking Change** Parameters & parameterEncoding in `TargetType` from [@Dschee](http://github.com/Dschee) (#1147).
-- Default value for `task` parameter in `Endpoint` initializer from [@SD10](http://github.com/SD10) (#1252).
+- **Breaking Change** Parameters & parameterEncoding in `TargetType` from [@Dschee](http://github.com/Dschee) ([#1147](https://github.com/Moya/Moya/pull/1147)).
+- Default value for `task` parameter in `Endpoint` initializer from [@SD10](http://github.com/SD10) ([#1252](https://github.com/Moya/Moya/pull/1252)).
 

--- a/Changelog Guidelines.md
+++ b/Changelog Guidelines.md
@@ -9,9 +9,9 @@ We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.
 
 ## [9.0.0] - 2017-09-04
 ### Added
-- Tests for `Single<Response>` operators from @freak4pc (#1229).
+- Tests for `Single<Response>` operators from [@freak4pc](http://github.com/freak4pc) (#1229).
 
 ### Removed
-- **Breaking Change** Parameters & parameterEncoding in `TargetType` from @Dschee (#1147).
-- Default value for `task` parameter in `Endpoint` initializer from @SD10 (#1252).
+- **Breaking Change** Parameters & parameterEncoding in `TargetType` from [@Dschee](http://github.com/Dschee) (#1147).
+- Default value for `task` parameter in `Endpoint` initializer from [@SD10](http://github.com/SD10) (#1252).
 

--- a/Changelog Guidelines.md
+++ b/Changelog Guidelines.md
@@ -1,17 +1,37 @@
 # Changelog Guidelines
 
-We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) with additions: 
+Here you can find the general guidelines for maintaining the Changelog (or adding new entry). We follow the guidelines from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) with few additions. 
 
-- PR number at the end of the entry
-- **Breaking change** label in breaking change entries. Additionally these entries should be at the top of the list of changes.
+## Guiding Principles
+- Changelogs are for humans, not machines.
+- There should be an entry for every single version.
+- The same types of changes should be grouped.
+- Versions and sections should be linkable.
+- The latest version comes first.
+- The release date of each versions is displayed.
+- Mention whether you follow Semantic Versioning.
+
+... with Moya-specific additions:
+- Keep an unreleased section at the top.
+- Add PR number and a GitHub tag at the end of each entry.
+- Each breaking change entry should have **Breaking Change** label at the beginning of this entry.
+- **Breaking Change** entries should be placed at the top of the section it's in.
+
+## Types of changes
+- **Added** for new features.
+- **Changed** for changes in existing functionality.
+- **Deprecated** for soon-to-be removed features.
+- **Removed** for now removed features.
+- **Fixed** for any bug fixes.
+- **Security** in case of vulnerabilities.
 
 ## Example:
 
 ## [9.0.0] - 2017-09-04
 ### Added
-- Tests for `Single<Response>` operators from [@freak4pc](http://github.com/freak4pc) ([#1229](https://github.com/Moya/Moya/pull/1229)).
+- Tests for `Single<Response>` operators. [#1229](https://github.com/Moya/Moya/pull/1229) by [@freak4pc](http://github.com/freak4pc)
 
-### Removed
-- **Breaking Change** Parameters & parameterEncoding in `TargetType` from [@Dschee](http://github.com/Dschee) ([#1147](https://github.com/Moya/Moya/pull/1147)).
-- Default value for `task` parameter in `Endpoint` initializer from [@SD10](http://github.com/SD10) ([#1252](https://github.com/Moya/Moya/pull/1252)).
+### Changed
+- **Breaking Change** `TargetType` so it doesn't have `parameters` & `parameterEncoding`. Instead, `task` property offer similar functionalities. [#1147](https://github.com/Moya/Moya/pull/1147) by [@Dschee](http://github.com/Dschee)
+- `Endpoint` initializer so it doesn't have default `task` argument. [#1252](https://github.com/Moya/Moya/pull/1252) by [@SD10](http://github.com/SD10)
 


### PR DESCRIPTION
Wasn't sure if it's the right place, but yeah. I also wasn't sure with the `from` keyword before the tag of a person who did a change. We may consider alternatives like `by` or just a `-`.

### Follow-up steps (after merge):
- [ ] Change [Rakefile's release route](https://github.com/Moya/Moya/blob/master/Rakefile#L178) accordingly (name/release date)
- [x] Update Danger to point to this documentation
- [ ] Slowly update old Changelog entries

Let me know what do you guys think!